### PR TITLE
Allow Unicode paths for loading mods and DLLs

### DIFF
--- a/include/modengine/settings.h
+++ b/include/modengine/settings.h
@@ -60,7 +60,7 @@ private:
     template <>
     std::optional<fs::path> node_to_val(toml::node* node)
     {
-        auto fs_path = std::filesystem::path(node->as_string()->get());
+        auto fs_path = fs::path(node->value<std::wstring>().value());
 
         // if we don't have an absolute path, relativize it to the path we loaded configuration from
         if (!fs_path.is_absolute()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,7 +64,7 @@ int WINAPI modengine_entrypoint(void)
     try {
         mod_engine_global->attach();
     } catch (std::exception& e) {
-        error("Failed to attach modengine {}", e.what());
+        error("Failed to attach modengine: {}", e.what());
     }
 
     return hooked_entrypoint.original();

--- a/src/modengine/ext/base/base_extension.cpp
+++ b/src/modengine/ext/base/base_extension.cpp
@@ -67,9 +67,9 @@ void ModEngineBaseExtension::on_attach()
     }
 #endif
 
-    const auto dinput8_path = util::system_directory() / "dinput8.dll";
+    const auto dinput8_path = util::system_directory().string() + "dinput8.dll";
 
-    register_hook(ALL, &hooked_DirectInput8Create, dinput8_path.string(), "DirectInput8Create", DirectInput8Create);
+    register_hook(ALL, &hooked_DirectInput8Create, dinput8_path, "DirectInput8Create", DirectInput8Create);
 
 #if 0
     lifecycle::on_frame.connect(m_render_overlay_cb);

--- a/src/modengine/ext/mod_loader/mod_loader_extension.cpp
+++ b/src/modengine/ext/mod_loader/mod_loader_extension.cpp
@@ -53,9 +53,9 @@ void ModLoaderExtension::on_attach()
     register_patch(DS3, loose_params_aob_2, replace_with<uint8_t>({ 0x0F, 0x84, 0xc5, 0x00, 0x00, 0x00 }));
     register_patch(DS3, loose_params_aob_3, replace_with<uint8_t>({ 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 }));
 
-    const auto kernel32_path = util::system_directory() / "kernel32.dll";
+    const auto kernel32_path = util::system_directory().string() + "kernel32.dll";
 
-    register_hook(ALL, &hooked_CreateFileW, kernel32_path.string(), "CreateFileW", tCreateFileW);
+    register_hook(ALL, &hooked_CreateFileW, kernel32_path, "CreateFileW", tCreateFileW);
     register_hook(DS3, &hooked_virtual_to_archive_path_ds3, util::rva2addr(0x7d660), virtual_to_archive_path_ds3);
     register_hook(ELDEN_RING, &hooked_virtual_to_archive_path_eldenring, virtual_to_archive_path_er_aob, virtual_to_archive_path_eldenring, SCAN_CALL_INST);
 
@@ -65,7 +65,7 @@ void ModLoaderExtension::on_attach()
             continue;
         }
 
-        info("Installing mod location {}", mod.location);
+        info(L"Installing mod location {}", mod.location);
 
         auto mod_path = resolve_mod_path(mod);
         if (mod_path) {

--- a/src/modengine/ext/mod_loader/mod_loader_extension.h
+++ b/src/modengine/ext/mod_loader/mod_loader_extension.h
@@ -9,18 +9,18 @@ namespace modengine::ext {
 
 struct ModInfo {
 public:
-    std::string name;
-    std::string location;
+    std::wstring name;
+    std::wstring location;
     bool enabled;
 
     bool from_toml(ConfigReader& v)
     {
-        auto loc = v.read_config_option<std::string>({ "path" });
+        auto loc = v.read_config_option<std::wstring>({ "path" });
         if (!loc) {
             return false;
         }
 
-        name = v.read_config_option<std::string>({ "name" }).value_or("Unknown");
+        name = v.read_config_option<std::wstring>({ "name" }).value_or(L"Unknown");
         enabled = v.read_config_option<bool>({ "enabled" }).value_or(true);
         location = loc.value();
 

--- a/src/modengine/extension_set.cpp
+++ b/src/modengine/extension_set.cpp
@@ -50,14 +50,14 @@ void ExtensionSet::load_extensions(std::vector<fs::path> dlls, bool enumerate_mo
 
         auto module = LoadLibraryW(dll.c_str());
         if (module == nullptr) {
-            error("Failed to load DLL {}", dll.string());
+            error(L"Failed to load DLL {}", dll.wstring());
             continue;
         }
 
-        info("Loaded external DLL {}", dll.string());
+        info(L"Loaded external DLL {}", dll.wstring());
 
         if (!load_extension(module)) {
-            warn("External dll {} at base address {:p} is not a modengine extension", dll.string(), fmt::ptr((void*)module));
+            warn(L"External dll {} at base address {:p} is not a modengine extension", dll.wstring(), fmt::ptr((void*)module));
         }
     }
 }

--- a/src/modengine/script_host.cpp
+++ b/src/modengine/script_host.cpp
@@ -48,15 +48,15 @@ void ScriptHost::load_script(const fs::path& path)
     sol::state_view state(m_state);
     sol::environment loader_env(state, sol::create, state.globals());
 
-    info("Loading script from {}", path.string());
+    info(L"Loading script from {}", path.wstring());
 
     loader_env["register_callback"] = [&](std::string name, sol::function fn) {
         const ScriptCallback& callback = ScriptCallback {
             fn,
-            path.string()
+            path.wstring()
         };
 
-        info("Registered {} callback for {}", name, path.string());
+        info(L"Registered {} callback for {}", std::wstring(name.begin(), name.end()), path.wstring());
 
         m_script_callbacks.insert({ name, callback });
     };
@@ -72,7 +72,7 @@ void ScriptHost::load_script(const fs::path& path)
 void ScriptHost::load_scripts(const std::vector<fs::path>& script_roots)
 {
     for (auto& root : script_roots) {
-        info("Searching for scripts in root: {}", root.string());
+        info(L"Searching for scripts in root: {}", root.wstring());
 
         for (auto& candidate : fs::recursive_directory_iterator(root)) {
             auto& candidate_path = candidate.path();
@@ -94,7 +94,7 @@ void ScriptHost::reload()
         for (const auto& [path, time] : m_script_update_times) {
             auto last_update = fs::last_write_time(path);
             if ((last_update - time) > 2s) {
-                debug("{} has changed, reloading", path.string());
+                debug(L"{} has changed, reloading", path.wstring());
 
                 load_script(path);
             }

--- a/src/modengine/settings_loader.cpp
+++ b/src/modengine/settings_loader.cpp
@@ -10,7 +10,7 @@ using namespace spdlog;
 bool SettingsLoader::load_toml_into(Settings& settings, const fs::path& path)
 {
     try {
-        auto config = toml::parse_file(path.string());
+        auto config = toml::parse_file(path.wstring());
         settings.m_config = config;
     } catch (const toml::parse_error& e) {
         error("Failed to load config {}", e.what());


### PR DESCRIPTION
## Description

ME2 doesn't currently support mod paths with funky characters like Á. This locks out a lot of people with languages such as Portuguese from running ME2 from their desktops/user folders, when they have such characters in their name.

Here I tried to enable this by changing strings I saw to wstrings. Thankfully the used libraries like TOML++ and CLI seem to already support Unicode.

On the way I had to change a couple things about how system paths are loaded in extensions because I would get a "path too long" error.

I genuinely have no idea about C++ and this was my first time ever even working on any C++ program, so things may be silly.

## Reproduction
Put mods and/or DLLs in folders with funky characters, then try to load them with ME2.

## Note
It would be nice if - assuming the PR passes fine - this could be released in a new preview build, because this would really cut down tech support effort in mod communities, due to eliminating often-unexplicable errors when people unpack mods/ME2 in their Desktop/Documents folders while having a Unicode username.

Metis Mod Launcher by HazelnutCheese would also benefit from this, as it puts profile TOMLs into AppData.