### PR TITLE
Don't call wcslen() on char* string

### DIFF
--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -161,7 +161,7 @@ int main()
     auto create_process_addr = GetProcAddress(kernel32, "CreateProcessW");
 
     auto exec_path_env = std::getenv("PATH");
-    auto exec_path = std::wstring(exec_path_env, exec_path_env + wcslen(reinterpret_cast<const wchar_t*>(exec_path_env)));
+    auto exec_path = std::wstring(exec_path_env, exec_path_env + strlen(exec_path_env));
     exec_path.append(L";");
     exec_path.append(modengine_dll_path.parent_path().native());
 


### PR DESCRIPTION
getenv() gets us ASCII string. Reinterpret casting it to wide char and calling wcslen() can end on a different NUL character in the env variables block, depending if the lenght of PATH is even or odd.

Calling strlen() is the right thing to do to get the real length, std::wstring constructor know how to deal with ASCII strings.

This fixes eldenring.exe not starting due to not finding lua.dll on some systems after hooking.