### PR TITLE
Feat/wwise file location resolver hook

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ name: hosted-pure-workflow
 on:
   push:
     branches:
-      - main
+      - *
   pull_request:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ name: hosted-pure-workflow
 on:
   push:
     branches:
-      - '*'
+      - '*/*'
   pull_request:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ name: hosted-pure-workflow
 on:
   push:
     branches:
-      - '*/*'
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ name: hosted-pure-workflow
 on:
   push:
     branches:
-      - *
+      - '*'
   pull_request:
     branches:
       - main

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(modengine2 SHARED
         modengine/ext/debug_menu/ds3/_DS3GameProperties.asm
         modengine/ext/mod_loader/archive_file_overrides.cpp
         modengine/ext/mod_loader/mod_loader_extension.cpp
+        modengine/ext/mod_loader/wwise_file_overrides.cpp
         modengine/ext/profiling/profiling_extension.cpp
         modengine/ext/profiling/profiler_trampoline.asm
         modengine/ext/profiling/main_loop.cpp

--- a/src/modengine/ext/mod_loader/archive_file_overrides.cpp
+++ b/src/modengine/ext/mod_loader/archive_file_overrides.cpp
@@ -42,8 +42,6 @@ namespace modengine::ext {
 // the easiest and most robust way to do this. It also has the bonus of allowing files that don't go through the asset system
 // (like the data archives and some of the sounds) to be overridable.
 
-namespace fs = std::filesystem;
-
 concurrency::concurrent_unordered_map<std::wstring, std::optional<std::filesystem::path>> archive_override_paths;
 concurrency::concurrent_unordered_map<std::wstring, std::optional<std::filesystem::path>> file_override_paths;
 

--- a/src/modengine/ext/mod_loader/archive_file_overrides.h
+++ b/src/modengine/ext/mod_loader/archive_file_overrides.h
@@ -4,9 +4,12 @@
 #include "gametypes/dantelion/dlstring.h"
 
 #include <set>
+#include <filesystem>
 #include <concurrent_vector.h>
 
 namespace modengine::ext {
+
+namespace fs = std::filesystem;
 
 // String type used in DS2/DS3
 typedef struct
@@ -42,5 +45,7 @@ extern concurrency::concurrent_vector<std::wstring> hooked_file_roots;
 HANDLE WINAPI tCreateFileW(LPCWSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode,
     LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes,
     HANDLE hTemplateFile);
+
+std::optional<fs::path> find_override_file(const fs::path& game_path);
 
 }

--- a/src/modengine/ext/mod_loader/mod_loader_extension.cpp
+++ b/src/modengine/ext/mod_loader/mod_loader_extension.cpp
@@ -19,8 +19,7 @@ auto loose_params_aob_2 = util::hex_string("0F 85 C5 00 00 00 48 8D 4C 24 28");
 auto virtual_to_archive_path_er_aob = util::hex_aob("e8 ?? ?? ?? ?? 48 83 7b 20 08 48 8d 4b 08 72 03 48 8b 09 4c 8b 4b 18 41 b8 05 00 00 00 4d 3b c8");
 auto virtual_to_archive_path_ac6_aob = util::hex_aob("cf e8 ?? ?? ?? ?? 48 83 7b 20 08 48 8d 4b 08 72 03 48 8b 09 4c 8b 4b 18 41 b8 05 00 00 00 4d 3b c8");
 
-//auto create_io_hook_file_descriptor_er_aob = util::hex_aob("e8 ?? ?? ?? ?? 48 83 7b 20 08 48 8d 4b 08 72 03 48 8b 09 4c 8b 4b 18 41 b8 05 00 00 00 4d 3b c8");
-auto ak_file_location_resolver_open_ac6_aob = util::hex_aob("4c 89 74 24 28 48 8b 84 24 90 00 00 00 48 89 44 24 20 4c 8b ce 45 8b c4 49 8b d7 48 8b cd e8 ?? ?? ?? ?? 8b d8");
+auto ak_file_location_resolver_open_aob = util::hex_aob("4c 89 74 24 28 48 8b 84 24 90 00 00 00 48 89 44 24 20 4c 8b ce 45 8b c4 49 8b d7 48 8b cd e8 ?? ?? ?? ?? 8b d8");
 
 static fs::path primary_mod_path(const Settings& settings)
 {
@@ -64,7 +63,8 @@ void ModLoaderExtension::on_attach()
     register_hook(DS3, &hooked_virtual_to_archive_path_ds3, util::rva2addr(0x7d660), virtual_to_archive_path_ds3);
     register_hook(ELDEN_RING, &hooked_virtual_to_archive_path_eldenring, virtual_to_archive_path_er_aob, 0x0, virtual_to_archive_path_eldenring, SCAN_CALL_INST);
     register_hook(ARMORED_CORE_6, &hooked_virtual_to_archive_path_eldenring, virtual_to_archive_path_ac6_aob, 0x1, virtual_to_archive_path_eldenring, SCAN_CALL_INST);
-    register_hook(ARMORED_CORE_6, &hooked_ak_file_location_resolver_open, ak_file_location_resolver_open_ac6_aob, 0x1E, ak_file_location_resolver_open, SCAN_CALL_INST);
+    register_hook(ELDEN_RING, &hooked_ak_file_location_resolver_open, ak_file_location_resolver_open_aob, 0x1E, ak_file_location_resolver_open, SCAN_CALL_INST);
+    register_hook(ARMORED_CORE_6, &hooked_ak_file_location_resolver_open, ak_file_location_resolver_open_aob, 0x1E, ak_file_location_resolver_open, SCAN_CALL_INST);
 
     auto config = get_config<ModLoaderConfig>();
     for (const auto& mod : config.mods) {

--- a/src/modengine/ext/mod_loader/mod_loader_extension.cpp
+++ b/src/modengine/ext/mod_loader/mod_loader_extension.cpp
@@ -1,5 +1,6 @@
 #include "mod_loader_extension.h"
 #include "archive_file_overrides.h"
+#include "wwise_file_overrides.h"
 
 #include "modengine/util/hex_string.h"
 #include "modengine/util/platform.h"
@@ -17,6 +18,9 @@ auto loose_params_aob_2 = util::hex_string("0F 85 C5 00 00 00 48 8D 4C 24 28");
 
 auto virtual_to_archive_path_er_aob = util::hex_aob("e8 ?? ?? ?? ?? 48 83 7b 20 08 48 8d 4b 08 72 03 48 8b 09 4c 8b 4b 18 41 b8 05 00 00 00 4d 3b c8");
 auto virtual_to_archive_path_ac6_aob = util::hex_aob("cf e8 ?? ?? ?? ?? 48 83 7b 20 08 48 8d 4b 08 72 03 48 8b 09 4c 8b 4b 18 41 b8 05 00 00 00 4d 3b c8");
+
+//auto create_io_hook_file_descriptor_er_aob = util::hex_aob("e8 ?? ?? ?? ?? 48 83 7b 20 08 48 8d 4b 08 72 03 48 8b 09 4c 8b 4b 18 41 b8 05 00 00 00 4d 3b c8");
+auto ak_file_location_resolver_open_ac6_aob = util::hex_aob("4c 89 74 24 28 48 8b 84 24 90 00 00 00 48 89 44 24 20 4c 8b ce 45 8b c4 49 8b d7 48 8b cd e8 ?? ?? ?? ?? 8b d8");
 
 static fs::path primary_mod_path(const Settings& settings)
 {
@@ -60,6 +64,7 @@ void ModLoaderExtension::on_attach()
     register_hook(DS3, &hooked_virtual_to_archive_path_ds3, util::rva2addr(0x7d660), virtual_to_archive_path_ds3);
     register_hook(ELDEN_RING, &hooked_virtual_to_archive_path_eldenring, virtual_to_archive_path_er_aob, 0x0, virtual_to_archive_path_eldenring, SCAN_CALL_INST);
     register_hook(ARMORED_CORE_6, &hooked_virtual_to_archive_path_eldenring, virtual_to_archive_path_ac6_aob, 0x1, virtual_to_archive_path_eldenring, SCAN_CALL_INST);
+    register_hook(ARMORED_CORE_6, &hooked_ak_file_location_resolver_open, ak_file_location_resolver_open_ac6_aob, 0x1E, ak_file_location_resolver_open, SCAN_CALL_INST);
 
     auto config = get_config<ModLoaderConfig>();
     for (const auto& mod : config.mods) {

--- a/src/modengine/ext/mod_loader/wwise_file_overrides.cpp
+++ b/src/modengine/ext/mod_loader/wwise_file_overrides.cpp
@@ -41,20 +41,6 @@ namespace fs = std::filesystem;
 
 using namespace spdlog;
 
-std::optional<fs::path> find_override_file(const fs::path game_path)
-{
-    for (const auto& root : hooked_file_roots) {
-        trace(L"Searching for {} in {}", game_path.wstring(), root);
-
-        auto file_path = root / fs::path(game_path);
-        if (fs::exists(file_path)) {
-            return file_path;
-        }
-    }
-
-    return {};
-}
-
 const wchar_t* prefixes[3] = {
     L"sd/",
     L"sd/enus/",

--- a/src/modengine/ext/mod_loader/wwise_file_overrides.cpp
+++ b/src/modengine/ext/mod_loader/wwise_file_overrides.cpp
@@ -97,7 +97,7 @@ std::optional<std::wstring> normalize_filename(const std::wstring path) {
 
 ScannedHook<decltype(&ak_file_location_resolver_open)> hooked_ak_file_location_resolver_open;
 
-void* __cdecl ak_file_location_resolver_open(UINT64 p1, wchar_t* path, UINT64 openMode, UINT64 p4, UINT64 p5, UINT64 p6)
+void* __cdecl ak_file_location_resolver_open(UINT64 p1, wchar_t* path, AKOpenMode openMode, UINT64 p4, UINT64 p5, UINT64 p6)
 {
     std::wstring lookup(path);
     debug(L"sd.bhd entry requested: {}", lookup);
@@ -114,7 +114,7 @@ void* __cdecl ak_file_location_resolver_open(UINT64 p1, wchar_t* path, UINT64 op
     }
 
     auto override_path_string = override.value().wstring();
-    return hooked_ak_file_location_resolver_open.original(p1, override_path_string.data(), 0, p4, p5, p6);
+    return hooked_ak_file_location_resolver_open.original(p1, override_path_string.data(), AKOpenMode::READ, p4, p5, p6);
 }
 
 }

--- a/src/modengine/ext/mod_loader/wwise_file_overrides.cpp
+++ b/src/modengine/ext/mod_loader/wwise_file_overrides.cpp
@@ -88,7 +88,7 @@ std::optional<fs::path> find_override(const std::wstring filename)
 }
 
 std::optional<std::wstring> normalize_filename(const std::wstring path) {
-    if (path.length() > 3 && path.substr(0, 4) == L"sd:/") {
+    if (path.starts_with(L"sd:/")) {
         return std::wstring(path.substr(4));
     }
 

--- a/src/modengine/ext/mod_loader/wwise_file_overrides.cpp
+++ b/src/modengine/ext/mod_loader/wwise_file_overrides.cpp
@@ -1,0 +1,94 @@
+#include <filesystem>
+
+#include "wwise_file_overrides.h"
+#include "archive_file_overrides.h"
+
+namespace modengine::ext {
+
+// This hook the IAkFileLocationResolver::open() method. It takes in a path and a so-called openMode. This openMode parameter
+// is of type AkOpenMode which is an enum with 4 states: Read, Write, WriteOverwrite and ReadWrite. Based on this parameter
+// the IAkFileLocationResolver implementation might acquire the file bytes different. Passing in any of these 4 invariants
+// will cause this function to yield an FileOperator used for sourcing the file bytes. FromSoftware funnily enough added
+// another invariant to AKOpenMode, dec 9, which will instead yield an EBLFileOperator, causing the reads to happen from
+// the bhd/bdt. This unfortunately happens without touching the usual virtual path lookup which ME2 already hooks.
+// In order to selectively make it read from disk again this checks if an override file exists and sets the openMode
+// back from 9 to Read. Then a relative path must be passed as a parameter.
+//
+// This is a messy one though:
+// Figuring out if there is an override isn't straight forward. The hooked function gets invoked with a virtual path string
+// ex: `sd:/50846376.wem`. Wwise uses subdirectories for localized content, meaning that the WEM example makes Wwise look
+// in `/50846376.wem` but also in `enus/50846376.wem` (or `ja/50846376.wem` for AC6 which has `ja` as an extra locale
+// for some audio and BNKs). To make matters even worse, Elden Ring sorts the WEMs into a subdir (`wem/`) and then
+// another subdir based on the first two digits of the WEM. So above example will spawn lookups in `/wem/50/50846376.wem`
+// and `enus/wem/50/50846376.wem`. In order to figure out if there is an override we will need to look in multiple directories
+// per request. Luckily, aside from boot, it doesn't load a lot of files.
+//
+// Also, worth pointing out that not all paths passed to this hook will have the `sd:/` prefix. So we cannot get away with the
+// usual prefix / rewrite trick and will have to allocate a completely new string.
+
+namespace fs = std::filesystem;
+
+using namespace spdlog;
+
+std::optional<fs::path> find_override_file(const fs::path game_path)
+{
+    for (const auto& root : hooked_file_roots) {
+        trace(L"Searching for {} in {}", game_path.wstring(), root);
+
+        auto file_path = root / fs::path(game_path);
+        if (fs::exists(file_path)) {
+            return file_path;
+        }
+    }
+
+    return {};
+}
+
+const wchar_t* prefixes[3] = {
+    L"sd/",
+    L"sd/enus/",
+    L"sd/ja/",
+};
+
+std::optional<fs::path> find_override(const std::wstring filename)
+{
+    for (auto prefix: prefixes) {
+        if (auto override = find_override_file(prefix+filename)) {
+            return override;
+        }
+    }
+
+    return {};
+}
+
+std::optional<std::wstring> normalize_filename(const std::wstring path) {
+    if (path.length() > 3 && path.substr(0, 4) == L"sd:/") {
+        return std::wstring(path.substr(4));
+    }
+
+    return {};
+}
+
+ScannedHook<decltype(&ak_file_location_resolver_open)> hooked_ak_file_location_resolver_open;
+
+void* __cdecl ak_file_location_resolver_open(UINT64 p1, wchar_t* path, UINT64 openMode, UINT64 p4, UINT64 p5, UINT64 p6)
+{
+    std::wstring lookup(path);
+    debug(L"sd.bhd entry requested: {}", lookup);
+
+    auto normalized = normalize_filename(lookup);
+    if (!normalized.has_value()) {
+        return hooked_ak_file_location_resolver_open.original(p1, path, openMode, p4, p5, p6);
+    }
+
+    auto filename = normalized.value();
+    auto override = find_override(filename);
+    if (!override.has_value()) {
+        return hooked_ak_file_location_resolver_open.original(p1, path, openMode, p4, p5, p6);
+    }
+
+    auto override_path_string = override.value().wstring();
+    return hooked_ak_file_location_resolver_open.original(p1, override_path_string.data(), 0, p4, p5, p6);
+}
+
+}

--- a/src/modengine/ext/mod_loader/wwise_file_overrides.cpp
+++ b/src/modengine/ext/mod_loader/wwise_file_overrides.cpp
@@ -50,8 +50,7 @@ const wchar_t* prefixes[3] = {
     L"sd/ja/",
 };
 
-std::optional<fs::path> find_override(const std::wstring filename)
-{
+std::optional<fs::path> check_paths(const std::wstring filename) {
     for (auto prefix: prefixes) {
         if (auto override = find_override_file(prefix+filename)) {
             return override;
@@ -59,6 +58,22 @@ std::optional<fs::path> find_override(const std::wstring filename)
     }
 
     return {};
+}
+
+std::optional<fs::path> find_override(const std::wstring filename)
+{
+    // TODO: can be based on game specified instead of always applied.
+    // Check wem/<first to digits of filename>/<filename> too since ER uses this format
+    if (filename.ends_with(L".wem")) {
+        auto wem_path = L"wem/" + filename.substr(0,2) + L"/" + filename;
+        auto wem_path_result = check_paths(wem_path);
+
+        if (wem_path_result.has_value()) {
+            return wem_path_result;
+        }
+    }
+
+    return check_paths(filename);
 }
 
 std::optional<std::wstring> normalize_filename(const std::wstring path) {

--- a/src/modengine/ext/mod_loader/wwise_file_overrides.cpp
+++ b/src/modengine/ext/mod_loader/wwise_file_overrides.cpp
@@ -12,7 +12,7 @@ namespace modengine::ext {
 // another invariant to AKOpenMode, dec 9, which will instead yield an EBLFileOperator, causing the reads to happen from
 // the bhd/bdt. This unfortunately happens without touching the usual virtual path lookup which ME2 already hooks.
 // In order to selectively make it read from disk again this checks if an override file exists and sets the openMode
-// back from 9 to Read. Then a relative path must be passed as a parameter.
+// back from 9 to Read. Then an absolute path must be passed as a parameter.
 //
 // This is a messy one though:
 // Figuring out if there is an override isn't straight forward. The hooked function gets invoked with a virtual path string

--- a/src/modengine/ext/mod_loader/wwise_file_overrides.h
+++ b/src/modengine/ext/mod_loader/wwise_file_overrides.h
@@ -4,7 +4,17 @@
 
 namespace modengine::ext {
 
-void* __cdecl ak_file_location_resolver_open(UINT64 p1, wchar_t* path, UINT64 p3, UINT64 p4, UINT64 p5, UINT64 p6);
+enum AKOpenMode : uint32_t {
+    READ            = 0,
+    WRITE           = 1,
+    WRITE_OVERWRITE = 2,
+    READ_WRITE      = 3,
+
+    // Custom mode specific to From Software's implementation
+    READ_EBL        = 9,
+};
+
+void* __cdecl ak_file_location_resolver_open(UINT64 p1, wchar_t* path, AKOpenMode openMode, UINT64 p4, UINT64 p5, UINT64 p6);
 
 extern ScannedHook<decltype(&ak_file_location_resolver_open)> hooked_ak_file_location_resolver_open;
 

--- a/src/modengine/ext/mod_loader/wwise_file_overrides.h
+++ b/src/modengine/ext/mod_loader/wwise_file_overrides.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "modengine/hook_set.h"
+
+namespace modengine::ext {
+
+void* __cdecl ak_file_location_resolver_open(UINT64 p1, wchar_t* path, UINT64 p3, UINT64 p4, UINT64 p5, UINT64 p6);
+
+extern ScannedHook<decltype(&ak_file_location_resolver_open)> hooked_ak_file_location_resolver_open;
+
+}


### PR DESCRIPTION
This PR makes ME2 also facilitate wwise bnk replacements for Elden Ring (tested v1.10.0) and AC6 (tested 1.03.1 through 10.5.0).

It does so by pattern matching for a function in the games that seems responsible for providing either an EblFileOperator or a plain disk-backed FileOperator implementation. If a file operator implementation is requested for a bnk this hook asserts if there is a replacement file and will swap the EblFileOperator for the disk-backed one.

There is a lot to be said about the replacement detection. It's messy, it's bad and it's a lot of hand-wavy code that relies on the convention of FromSoftware developers. There is nothing I can think of to improve this and I'm open for suggestions.

I also feel like it's inefficient to always be doing a full set of filesystem lookups but it seems the hooked functions are called infrequently enough to not cause a significant performance hit.