### PR TITLE
Add vcpkg configuration for `overlay-ports`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,5 @@
+{
+    "overlay-ports": [
+        "third-party/vcpkg-overlays/"
+    ]
+}


### PR DESCRIPTION
This allows build without specifying `VCPKG_OVERLAY_PORTS` arg