### PR TITLE
Fixes for ME2 launch failures in some scenarios

### DIFF
--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -187,7 +187,7 @@ int main()
     wchar_t cmd[MAX_PATH] = {};
     wcscpy_s(cmd, app_cmd.c_str());
 
-    auto proc_flags = CREATE_NEW_PROCESS_GROUP;
+    auto proc_flags = 0;
     bool success = DetourCreateProcessWithDllW(
         cmd,
         nullptr,

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -231,7 +231,7 @@ int main()
         app_cwd.c_str(),
         &si,
         &pi,
-        fs::absolute(modengine_dll_path).native().c_str(),
+        fs::absolute(modengine_dll_path).string().c_str(),
         reinterpret_cast<PDETOUR_CREATE_PROCESS_ROUTINEW>(create_process_addr));
 
     auto status = E_OK;

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -51,46 +51,68 @@ static std::map<std::string, LaunchTarget> exe_names {
     { "armoredcore6.exe", ARMORED_CORE_6 },
 };
 
-std::wstring GetCurrentDirectory()
+namespace platform {
+std::wstring get_env_var(const std::wstring& name)
 {
-    wchar_t buffer[MAX_PATH];
-    GetModuleFileNameW(NULL, buffer, MAX_PATH);
-    std::string::size_type pos = std::wstring(buffer).find_last_of(L"\\/");
+    size_t buffer_size = GetEnvironmentVariableW(name.c_str(), nullptr, 0);
+    wchar_t buffer[buffer_size + 1];
 
-    return std::wstring(buffer).substr(0, pos);
+    std::wstring value;
+
+    if (buffer_size > 0) {
+        size_t len = GetEnvironmentVariableW(name.c_str(), &buffer[0], buffer_size + 1);
+        value.append(buffer, len);
+    }
+
+    return value;
+}
+
+void set_env_var(const std::wstring& name, const std::wstring& value)
+{
+    SetEnvironmentVariableW(name.c_str(), value.c_str());
+}
+
+fs::path get_launcher_directory()
+{
+    size_t buffer_size = GetModuleFileNameW(nullptr, nullptr, 0);
+    wchar_t buffer[buffer_size + 1];
+
+    if (buffer_size > 0) {
+        size_t len = GetModuleFileNameW(nullptr, buffer, buffer_size + 1);
+        fs::path launcher_path(std::wstring_view { buffer, len });
+
+        return launcher_path.parent_path();
+    }
+
+    return fs::current_path();
+}
+
 }
 
 int main()
 {
     auto logger = spdlog::stderr_color_mt("stderr");
+    auto launcher_directory = platform::get_launcher_directory();
 
-    wchar_t launcher_filename[MAX_PATH];
-
-    // This isn't always needed, but cli11 doesn't allow us to signal an error
-    // from the function that produces the default value for the modengine.dll path.
-    if (!GetModuleFileNameW(nullptr, launcher_filename, MAX_PATH)) {
-        return E_OS_ERROR;
-    }
 
     CLI::App app { "ModEngine Launcher" };
 
     LaunchTarget target = AUTODETECT;
     auto target_option = app.add_option("-t,--launch-target", target, "Launch target")
-        ->transform(CLI::CheckedTransformer(launch_target_names, CLI::ignore_case));
+                             ->transform(CLI::CheckedTransformer(launch_target_names, CLI::ignore_case));
 
     std::string target_path_string;
     auto target_path_option = app.add_option("-p,--game-path", target_path_string, "Path to game executable. Will autodetect if not specified.")
-        ->transform(CLI::ExistingFile);
+                                  ->transform(CLI::ExistingFile);
 
     std::string config_path_string;
     auto config_option = app.add_option("-c,--config", config_path_string, "ModEngine configuration file path")
-        ->transform(CLI::ExistingFile);
+                             ->transform(CLI::ExistingFile);
 
     bool suspend = false;
     app.add_option("-s,--suspend", suspend, "Start the game in a suspended state");
 
-    auto launcher_path = fs::path(launcher_filename);
-    auto modengine_dll_path = launcher_path.parent_path() / L"modengine2" / L"bin" / L"modengine2.dll";
+    auto modengine_dll_path = launcher_directory / L"modengine2" / L"bin" / L"modengine2.dll";
 
     app.add_option("--modengine-dll", modengine_dll_path, "ModEngine DLL file path (modengine2.dll)");
 
@@ -103,8 +125,7 @@ int main()
     std::optional<fs::path> app_path = std::nullopt;
 
     // First if the game path was specified, use that along with the specified target
-    if (!target_path_option->empty())
-    {
+    if (!target_path_option->empty()) {
         app_path = absolute(CLI::to_path(target_path_string)).parent_path().parent_path();
         if (target == AUTODETECT) {
             logger->error("Game target must be specified when supplying a manual path");
@@ -115,7 +136,7 @@ int main()
     // If the game target was not set, try to find a game exe in the current directory and infer from that
     if (target_option->empty()) {
         for (auto& name_kv : exe_names) {
-            auto exepath = launcher_path.parent_path() / name_kv.first;
+            auto exepath = launcher_directory / name_kv.first;
             if (fs::exists(exepath)) {
                 target = name_kv.second;
                 app_path = exepath.parent_path().parent_path(); // app_path is expected to be steam app path not exe path
@@ -133,7 +154,7 @@ int main()
 
     // If a config wasn't specified, try to load the default one for the game
     if (config_option->empty()) {
-        auto default_config_path = launcher_path.parent_path() / launch_params.default_config;
+        auto default_config_path = launcher_directory / launch_params.default_config;
         if (!fs::exists(default_config_path)) {
             logger->error("Could not find default config file at {}", default_config_path.string());
         }
@@ -164,28 +185,32 @@ int main()
     auto kernel32 = LoadLibraryW(L"kernel32.dll");
     auto create_process_addr = GetProcAddress(kernel32, "CreateProcessW");
 
-    auto exec_path_env = std::getenv("PATH");
-    auto exec_path = std::wstring(exec_path_env, exec_path_env + strlen(exec_path_env));
+    auto exec_path = platform::get_env_var(L"PATH");
     exec_path.append(L";");
     exec_path.append(modengine_dll_path.parent_path().native());
 
     auto config_path = CLI::to_path(config_path_string);
     if (config_path.is_relative()) {
-        const auto search_path = GetCurrentDirectory() / config_path;
-        config_path = absolute(search_path);
+        const auto search_path = launcher_directory / config_path;
+        config_path = fs::absolute(search_path);
     }
 
     // These are inherited by the game process we launch with Detours.
-    SetEnvironmentVariable(L"SteamAppId", launch_params.app_id.c_str());
-    SetEnvironmentVariable(L"MODENGINE_CONFIG", config_path.c_str());
-    SetEnvironmentVariable(L"PATH", exec_path.c_str());
+    platform::set_env_var(L"SteamAppId", launch_params.app_id);
+    platform::set_env_var(L"MODENGINE_CONFIG", config_path.native());
+    platform::set_env_var(L"PATH", exec_path);
 
     if (suspend || IsDebuggerPresent()) {
-        SetEnvironmentVariableW(L"MODENGINE_DEBUG_GAME", L"1");
+        platform::set_env_var(L"MODENGINE_DEBUG_GAME", L"1");
     }
 
-    wchar_t cmd[MAX_PATH] = {};
-    wcscpy_s(cmd, app_cmd.c_str());
+    std::wstring cmd_str = app_cmd.native();
+    size_t cmd_len = cmd_str.length();
+
+    wchar_t cmd[cmd_len + 1];
+    cmd[cmd_len] = 0;
+
+    wcsncpy_s(cmd, cmd_str.c_str(), cmd_len);
 
     auto proc_flags = 0;
     bool success = DetourCreateProcessWithDllW(
@@ -199,7 +224,7 @@ int main()
         app_cwd.c_str(),
         &si,
         &pi,
-        fs::absolute(modengine_dll_path).string().c_str(),
+        fs::absolute(modengine_dll_path).native().c_str(),
         reinterpret_cast<PDETOUR_CREATE_PROCESS_ROUTINEW>(create_process_addr));
 
     if (!success) {

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -214,8 +214,10 @@ int main()
     std::wstring cmd_str = app_cmd.native();
     size_t cmd_len = cmd_str.length();
 
-    wchar_t cmd[cmd_len + 1] = {};
-    wcsncpy_s(cmd, cmd_str.c_str(), cmd_len);
+    auto *cmd = new wchar_t[cmd_len + 1];
+    cmd[cmd_len] = 0;
+
+    wcscpy_s(cmd, cmd_len, cmd_str.c_str());
 
     auto proc_flags = 0;
     bool success = DetourCreateProcessWithDllW(


### PR DESCRIPTION
- Better interaction with tools that handle process priority (no longer create a new process group).
- Code that touches paths has been cleaned up to avoid any unsoundness with interpreting the data as UCS2.