### PR TITLE
Update README so that example config matches example folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Mod Engine 2 is a ground up rewrite of Mod Engine, a runtime code patching and i
 
 ```toml
 mods = [
-  { enabled = true, name = "default", path = "mod\\testmodName" },
-  { enabled = false, name = "default", path = "mod\\disabledTestmodName" },
+  { enabled = true, name = "BetterAshes ", path = "mod\\ashes" },
+  { enabled = true, name = "CleversMoveset", path = "mod\\moveset" },
+  { enabled = false, name = "EnemyRandomizer", path = "mod\\randomizer" },
 ]
 ```
 


### PR DESCRIPTION
It could be confusing for novices that 1) the example config doesn't match the folder structure shown and 2) both mod names were just 'default' 